### PR TITLE
haveValidSnapshot: fixed recording parameter

### DIFF
--- a/SnapshotTesting-Nimble/Classes/HaveValidSnapshot.swift
+++ b/SnapshotTesting-Nimble/Classes/HaveValidSnapshot.swift
@@ -27,7 +27,7 @@ public func haveValidSnapshot<Value, Format>(
             matching: value,
             as: strategy,
             named: name,
-            record: record,
+            record: recording,
             timeout: timeout,
             file: file,
             testName: testName,


### PR DESCRIPTION
It's passing the global `record`, instead of the parameter, which means the value is being ignored.

Note that `SnapshotTesting` does `recording || record` inside, so this isn't a breaking change.